### PR TITLE
fix: avoid write after end errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ const Emitter = require('events')
 const state = new Emitter()
 
 state.cssStream = new stream.PassThrough()
+
+state.cssStream.end = function () {}
+
 state.jsRegistered = false
 state.cssReady = false
 state.cssOpts = null


### PR DESCRIPTION
This fix aims at avoiding the errors related to b75b4fb.

The idea behind this is to ensure `state.cssStream` is always writable,
even when `extract-css` calls `WriteableStream.prototype.end` on it.