### PR TITLE
fix: avoid write after end errors

### DIFF
--- a/handler-js.js
+++ b/handler-js.js
@@ -79,6 +79,7 @@ function wreq (state, bundler, startFn) {
 
   update()
   bundler.on('update', update)
+  state.cssStream.on('finish', onCssStreamFinish)
 
   return handler
 
@@ -106,6 +107,12 @@ function wreq (state, bundler, startFn) {
       buffer = _buffer
       pending.emit('ready', prevError = err, pending = false)
     }))
+  }
+
+  function onCssStreamFinish () {
+    state.cssStream = new stream.PassThrough()
+    state.cssStream.on('finish', onCssStreamFinish)
+    state.cssStream.pipe(state.cssBuf)
   }
 
   // call the handler function


### PR DESCRIPTION
This fix aims at avoiding the errors related to b75b4fb.
The idea behind this is to ensure `state.cssStream` is always writable,
even when `extract-css` calls `WriteableStream.prototype.end` on it.

---
Disclaimer: I am not that experienced with node streams and thus don't know if this is the best way to do an "infinite" PassThrough; I'd be glad to get some hints / ideas on this.