### PR TITLE
Docs: Indicate css method uses sheetify

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Return an `html` stream. Cached by default. Includes livereload if
 - __opts.css:__ `css` entry point. Defaults to `/bundle.css`
 
 ### bankai.css(opts)
-Return a `css` stream.
+Return a `css` stream using [sheetify](https://github.com/stackcss/sheetify).
 Cached if `NODE_ENV=production`. Takes the following options:
-- __use:__ array of transforms. Empty by default.
+- __use:__ array of sheetify transforms. Empty by default.
 - __basedir:__ project base directory. Defaults to `process.cwd()`
 
 ### bankai.js(browserify, src, opts)


### PR DESCRIPTION
I was debugging for a while trying to figure out why `bankai.css({ use: [ 'sheetify' ] })` wasn't working. On inspecting the code it's clear that `sheetify` is already part of the mix, and `use` is just for transforms on top of sheetify. Hopefully this doc update makes that more clear.