### PR TITLE
bankai: require instance before run

### DIFF
--- a/handler-html.js
+++ b/handler-html.js
@@ -4,8 +4,6 @@ const hyperstream = require('hyperstream')
 const xtend = require('xtend')
 const bl = require('bl')
 
-const env = process.env.NODE_ENV
-
 module.exports = html
 
 // create html stream
@@ -20,9 +18,9 @@ function html (state) {
     }
     const htmlOpts = xtend(defaultOpts, opts)
     const html = htmlIndex(htmlOpts).pipe(createMetaTag())
-    const htmlBuf = (env === 'development')
-      ? html.pipe(lrScript()).pipe(bl())
-      : html.pipe(bl())
+    const htmlBuf = (state.optimize)
+      ? html.pipe(bl())
+      : html.pipe(lrScript()).pipe(bl())
 
     return function (req, res) {
       res.setHeader('Content-Type', 'text/html')

--- a/handler-js.js
+++ b/handler-js.js
@@ -16,12 +16,9 @@ function js (state) {
   return function (browserify, src, opts) {
     opts = opts || {}
 
-    assert.equal(typeof opts, 'object', 'opts should be an object')
-    assert.equal(typeof browserify, 'function', 'browserify should be a fn')
-    assert.equal(typeof src, 'string', 'src should be a location')
-
-    // signal to CSS that browserify is registered
-    state.jsRegistered = true
+    assert.equal(typeof opts, 'object', 'bankai/js: opts should be an object')
+    assert.equal(typeof browserify, 'function', 'bankai/js: browserify should be a fn')
+    assert.equal(typeof src, 'string', 'bankai/js: src should be a location')
 
     const baseBrowserifyOpts = {
       cache: {},
@@ -33,7 +30,7 @@ function js (state) {
 
     // enable css if registered
     if (state.cssOpts) {
-      if (!state.cssBuf || process.env.NODE_ENV === 'development') {
+      if (!state.cssBuf || !state.optimize) {
         state.cssBuf = bl()
         state.cssReady = false
       }
@@ -47,7 +44,7 @@ function js (state) {
       })
     }
 
-    if (process.env.NODE_ENV === 'development') {
+    if (!state.optimize) {
       b.plugin(errorify)
       b = watchify(b)
     }

--- a/index.js
+++ b/index.js
@@ -1,14 +1,29 @@
 const stream = require('readable-stream')
+const mutate = require('xtend/mutable')
 const Emitter = require('events')
 
-const state = new Emitter()
+const html = require('./handler-html')
+const css = require('./handler-css')
+const js = require('./handler-js')
 
-state.cssStream = new stream.PassThrough()
-state.jsRegistered = false
-state.cssReady = false
-state.cssOpts = null
-state.cssBuf = null
+module.exports = bankai
 
-exports.html = require('./handler-html')(state)
-exports.css = require('./handler-css')(state)
-exports.js = require('./handler-js')(state)
+// create a new bankai instance
+// (obj?) -> obj
+function bankai (opts) {
+  opts = opts || {}
+
+  const state = new Emitter()
+  state.cssStream = new stream.PassThrough()
+  state.cssBuf = null
+  state.jsRegistered = false
+  state.cssReady = false
+  state.cssOpts = null
+  mutate(state, opts)
+
+  return {
+    html: html(state),
+    css: css(state),
+    js: js(state)
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,8 @@ const bankai = require('../')
 test('html', function (t) {
   t.test('returns data', function (t) {
     t.plan(2)
-    const html = bankai.html()
+    const assets = bankai()
+    const html = assets.html()
     const server = http.createServer(function (req, res) {
       html(req, res).pipe(res)
     })
@@ -29,13 +30,15 @@ test('html', function (t) {
 test('css', function (t) {
   t.test('asserts input types', function (t) {
     t.plan(1)
-    t.throws(bankai.css.bind(null, 'foo'), /object/)
+    const assets = bankai()
+    t.throws(assets.css.bind(null, 'foo'), /object/)
   })
 
   t.test('returns data', function (t) {
     t.plan(2)
-    const css = bankai.css({ basedir: __dirname })
-    bankai.js(browserify, path.join(__dirname, './fixture.js'))
+    const assets = bankai()
+    const css = assets.css({ basedir: __dirname })
+    assets.js(browserify, path.join(__dirname, './fixture.js'))
     const server = http.createServer(function (req, res) {
       css(req, res).pipe(res)
     })
@@ -46,7 +49,6 @@ test('css', function (t) {
         res.pipe(concat(function (buf) {
           const str = String(buf)
           t.equal(res.headers['content-type'], 'text/css')
-          console.log(str)
           t.ok(/\.foo {}/.test(str), 'css is equal')
           server.close()
         }))
@@ -58,13 +60,15 @@ test('css', function (t) {
 test('js', function (t) {
   t.test('js asserts input types', function (t) {
     t.plan(2)
-    t.throws(bankai.js, /browserify/)
-    t.throws(bankai.js.bind(null, browserify), /src/)
+    const assets = bankai()
+    t.throws(assets.js, /browserify/)
+    t.throws(assets.js.bind(null, browserify), /src/)
   })
 
   t.test('js returns data', function (t) {
     t.plan(1)
-    const js = bankai.js(browserify, './test/fixture.js')
+    const assets = bankai()
+    const js = assets.js(browserify, './test/fixture.js')
     const server = http.createServer(function (req, res) {
       js(req, res).pipe(res)
     })
@@ -72,9 +76,20 @@ test('js', function (t) {
 
     http.get('http://localhost:' + getPort(server), function (res) {
       res.pipe(concat(function (buf) {
-        t.equal(res.headers['content-type'], 'application/javascript')
+        const actual = res.headers['content-type']
+        const expected = 'application/javascript'
+        t.equal(actual, expected, 'content type is equal')
         server.close()
       }))
     })
   })
+})
+
+test('__END__', function (t) {
+  t.on('end', function () {
+    setTimeout(function () {
+      process.exit(0)
+    }, 100)
+  })
+  t.end()
 })


### PR DESCRIPTION
Changes the API to require initialization before usage. Paves the way for cleaner internals. New option: `opts.optimize`; optimization toggle flag, rather than relying on env vars :sparkles:
```js
const browserify = require('browserify')
const bankai = require('bankai')
const http = require('http')
const path = require('path')

const client = path.join(__dirname, 'client.js')

const assets = bankai()
const js = assets.js(browserify, client)
const html = assets.html()
const css = assets.css()

http.createServer((req, res) => {
  switch req.url {
    case '/': return html(req, res).pipe(res)
    case '/bundle.js': return js(req, res).pipe(res)
    case '/bundle.css': return css(req, res).pipe(res)
    default: return res.statusCode = 404 && res.end('404 not found')
  }
}).listen(8080)
```
Thanks! :sparkles:

cc/ @marionebl 