### PR TITLE
start: fix flags

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -75,6 +75,7 @@ const cli = meow(`
     string: [
       'entry',
       'dir',
+      'open',
       'html.entry',
       'html.css',
       'html.title',


### PR DESCRIPTION
The `--open` flag was doing weird things; wasn't defined. Moved some exports to the top and helper functions to the bottom. Also pyramids. Sorry not sorry for the bike shed; I'd have a linter for this stuff but writing linters is hard so hah