### PR TITLE
build: add default path

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -12,6 +12,7 @@ module.exports = build
 
 const defaults = {
   optimize: false,
+  dir: 'dist',
   entry: '.',
   html: {},
   css: {},


### PR DESCRIPTION
Defaults building to `dist/` if no path was specified in `build`. Thanks!