### PR TITLE
fix: ensure node 4 compat

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -1,12 +1,14 @@
+'use strict'
+
+const resolveEntry = require('../lib/resolve-entry')
+const browserify = require('browserify')
+const parallel = require('run-parallel')
+const mkdirp = require('mkdirp')
+const xtend = require('xtend')
 const bankai = require('../')
 const path = require('path')
-const browserify = require('browserify')
-const resolve = require('resolve')
-const xtend = require('xtend')
-const fs = require('fs')
-const mkdirp = require('mkdirp')
-const parallel = require('run-parallel')
 const pump = require('pump')
+const fs = require('fs')
 
 module.exports = build
 
@@ -19,23 +21,13 @@ const defaults = {
   js: {}
 }
 
-const cwd = process.cwd()
-
-// resolve a path according to require.resolve algorithm
-// string -> string
-function resolveEntryFile (relativePath) {
-  const first = relativePath.charAt(0)
-  const entry = ['.', '/'].includes(first) ? relativePath : './' + relativePath
-  return resolve.sync(entry, {basedir: cwd})
-}
-
 function build (options, cb) {
   const assets = bankai({ optimize: true })
 
   const settings = xtend({}, defaults, options)
   const callback = cb || function () {}
 
-  const entryFile = resolveEntryFile(settings.entry)
+  const entryFile = resolveEntry(settings.entry)
   const outputDir = settings.dir
 
   // Register css & html if specified. Register js no matter what

--- a/bin/start.js
+++ b/bin/start.js
@@ -1,8 +1,10 @@
+'use strict'
+
+const resolveEntry = require('../lib/resolve-entry')
 const stringToStream = require('string-to-stream')
 const getServerPort = require('get-server-port')
 const serverRouter = require('server-router')
 const browserify = require('browserify')
-const resolve = require('resolve')
 const xtend = require('xtend')
 const http = require('http')
 const path = require('path')
@@ -32,7 +34,7 @@ function start (options, cb) {
   const opts = xtend({}, defaults, options)
   const callback = cb || function () {}
 
-  const entryFile = resolveEntryFile(opts.entry)
+  const entryFile = resolveEntry(opts.entry)
   const relativeEntry = path.relative(cwd, entryFile)
 
   const routes = []
@@ -85,12 +87,4 @@ function start (options, cb) {
 
     callback()
   })
-}
-
-// resolve a path according to require.resolve algorithm
-// string -> string
-function resolveEntryFile (relativePath) {
-  const first = relativePath.charAt(0)
-  const entry = ['.', '/'].includes(first) ? relativePath : './' + relativePath
-  return resolve.sync(entry, {basedir: cwd})
 }

--- a/handler-css.js
+++ b/handler-css.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const assert = require('assert')
 const stream = require('readable-stream')
 

--- a/handler-html.js
+++ b/handler-html.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const createHtml = require('create-html')
 const xtend = require('xtend')
 const stringToStream = require('string-to-stream')

--- a/handler-js.js
+++ b/handler-js.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const assert = require('assert')
 const bl = require('bl')
 const cssExtract = require('css-extract')

--- a/lib/resolve-entry.js
+++ b/lib/resolve-entry.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const resolve = require('resolve')
+const cwd = process.cwd()
+
+module.exports = resolveEntry
+
+// resolve a path according to require.resolve algorithm
+// string -> string
+function resolveEntry (id) {
+  const entry = ['.', '/'].indexOf(id.charAt(0)) > -1 ? id : './' + id
+  return resolve.sync(entry, {basedir: cwd})
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dependency-check": "^2.6.0",
     "is-html": "^1.0.0",
     "istanbul": "^0.4.4",
+    "openport": "0.0.4",
     "standard": "^8.0.0",
     "tape": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "files": [
     "index.js",
     "bin/*",
+    "lib/*",
     "client-hmr.js",
     "handler-*"
   ]


### PR DESCRIPTION
*  add 'use strict' to all files for node 4 block-scoping
*  remove usage of `Array.prototype.includes` in resolveEntryFile
*  rename `resolveEntryFile` to `resolveEntry`
*  move multiple `resolveEntry` implementations to `lib/resolve-entry`
*  order imports in `bin/build` according to length
*  add lib to allowed files in manifest

fixes #66