### PR TITLE
Serve bundle.css and bundle.js from absolute path

### DIFF
--- a/handler-html.js
+++ b/handler-html.js
@@ -12,8 +12,8 @@ function html (state) {
   return function initHtml (opts) {
     opts = opts || {}
     const defaultOpts = {
-      entry: 'bundle.js',
-      css: 'bundle.css',
+      entry: '/bundle.js',
+      css: '/bundle.css',
       head: '<meta name="viewport" content="width=device-width, initial-scale=1">'
     }
     const htmlOpts = xtend(defaultOpts, opts)


### PR DESCRIPTION
fixes #32, though as I mentioned in that issue I'm not sure whether this would break other use cases (ie. a site served at a subdirectory, `localhost/site-root/`). Just wanted to get conversation going because at the moment you can't serve an app with subroutes with bankai. Thoughts?