### PR TITLE
Depend on es2020/normalize.css for dev

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -47,7 +47,7 @@ const cli = meow(`
     Started bankai for index.js on http://localhost:1337
 
     $ bankai start --entry=basic
-    Started bankai fro basic/index.js on http://localhost:1337
+    Started bankai for basic/index.js on http://localhost:1337
 
     $ bankai start --port=3000
     Started bankai for index.js on http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -49,8 +49,10 @@
     "choo": "^3.2.0",
     "concat-stream": "^1.5.1",
     "dependency-check": "^2.6.0",
+    "es2020": "^1.1.9",
     "is-html": "^1.0.0",
     "istanbul": "^0.4.4",
+    "normalize.css": "^4.2.0",
     "openport": "0.0.4",
     "standard": "^8.0.0",
     "tape": "^4.6.0"


### PR DESCRIPTION
I noticed that in order to run example/basic es2020 and normalize.css must be installed. As such I think it makes sense to add them to the project's dev dependencies.