### PR TITLE
serve source maps 

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -54,7 +54,7 @@ const usage = `
       -O, --optimize          Optimize assets served by bankai [default: false]
       -p, --port=<n>          Bind bankai to <n> [default: 8080]
       -V, --verbose           Include debug messages
-      -d, --debug             Include sourcemaps
+      -d, --debug             Include sourcemaps [default: false]
 
   Examples:
     $ bankai index.js -p 8080            # start bankai on port 8080
@@ -106,7 +106,7 @@ function main (argv) {
 }
 
 function start (entry, argv, done) {
-  const assets = bankai(entry)
+  const assets = bankai(entry, argv)
   const port = argv.port
 
   http.createServer((req, res) => {

--- a/bin.js
+++ b/bin.js
@@ -17,11 +17,12 @@ const bankai = require('./')
 
 const argv = subarg(process.argv.slice(2), {
   string: [ 'open', 'port' ],
-  boolean: [ 'optimize', 'verbose', 'help', 'version' ],
+  boolean: [ 'optimize', 'verbose', 'help', 'version', 'debug' ],
   default: {
     optimize: false,
     open: false,
-    port: 8080
+    port: 8080,
+    debug: false
   },
   alias: {
     css: 'c',
@@ -31,7 +32,8 @@ const argv = subarg(process.argv.slice(2), {
     optimize: 'O',
     port: 'p',
     verbose: 'V',
-    version: 'v'
+    version: 'v',
+    debug: 'd'
   }
 })
 
@@ -52,6 +54,7 @@ const usage = `
       -O, --optimize          Optimize assets served by bankai [default: false]
       -p, --port=<n>          Bind bankai to <n> [default: 8080]
       -V, --verbose           Include debug messages
+      -d, --debug             Include sourcemaps
 
   Examples:
     $ bankai index.js -p 8080            # start bankai on port 8080

--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@ function Bankai (entry, opts) {
   this.cssQueue = []
 
   this._html = _html(opts.html)
+
+  if (opts.debug) opts.js = xtend(opts.js, {debug: true})
   this._createJs = _javascript(entry, opts.js, setCss)
 
   function setCss (css) {


### PR DESCRIPTION
Greetings 👋👋

allows for bankai to serve source maps as addressed in #53 

bankai kinda already had this ability with `bankai example.js --js [ --debug ]`

this just adds a bit of abstraction so `bankai example.js -d` or `bankai example.js --debug` works as well