### PR TITLE
Fix passing on css options to sheetify

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -26,14 +26,15 @@ const argv = subarg(process.argv.slice(2), {
   },
   alias: {
     css: 'c',
-    js: 'j',
+    debug: 'd',
     help: 'h',
+    html: 'H',
+    js: 'j',
     open: 'o',
     optimize: 'O',
     port: 'p',
     verbose: 'V',
-    version: 'v',
-    debug: 'd'
+    version: 'v'
   }
 })
 
@@ -48,13 +49,14 @@ const usage = `
 
     Options:
       -c, --css=<subargs>     Pass subarguments to sheetify
+      -d, --debug             Include sourcemaps [default: false]
       -h, --help              Print usage
+      -H, --html=<subargs>    Pass subarguments to create-html
       -j, --js=<subargs>      Pass subarguments to browserify
       -o, --open=<browser>    Open html in a browser [default: system default]
       -O, --optimize          Optimize assets served by bankai [default: false]
-      -p, --port=<n>          Bind bankai to <n> [default: 8080]
+      -p, --port=<n>          Bind bankai to a port [default: 8080]
       -V, --verbose           Include debug messages
-      -d, --debug             Include sourcemaps [default: false]
 
   Examples:
     $ bankai index.js -p 8080            # start bankai on port 8080

--- a/index.js
+++ b/index.js
@@ -19,31 +19,67 @@ function Bankai (entry, opts) {
 
   opts = opts || {}
 
+  opts.html = opts.html || {}
+  opts.css = opts.css || {}
+  opts.js = opts.js || {}
+
   assert.equal(typeof entry, 'string', 'bankai: entry should be a string')
   assert.equal(typeof opts, 'object', 'bankai: opts should be an object')
 
   const self = this
 
+  this.htmlDisabled = (opts.html === false)
+  this.cssDisabled = (opts.css === false)
   this.optimize = opts.optimize
-  this.htmlDisabled = opts.html
-  this.cssDisabled = opts.css
   this.cssQueue = []
 
-  this._html = _html(opts.html)
+  if (opts.debug) opts.js = xtend(opts.js, { debug: true })
 
-  if (opts.debug) opts.js = xtend(opts.js, {debug: true})
-  this._createJs = _javascript(entry, opts.js, setCss)
+  this._html = (function () {
+    const base = {
+      script: 'bundle.js',
+      css: (self.cssDisabled) ? null : 'bundle.css',
+      head: '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    }
+    const html = createHtml(xtend(base, opts.html))
+    return new Buffer(html)
+  })()
 
-  function setCss (css) {
-    self._css = css
-    while (self.cssQueue.length) self.cssQueue.shift()()
-  }
+  this._js = (function () {
+    const base = {
+      basedir: process.cwd(),
+      entries: [ entry ],
+      packageCache: {},
+      fullPaths: true,
+      cache: {}
+    }
+    const jsOpts = xtend(base, opts.js)
+
+    const b = (self.optimize)
+      ? browserify(jsOpts)
+      : watchify(browserify(jsOpts))
+
+    if (!self.cssDisabled) {
+      b.plugin(cssExtract, { out: createCssStream })
+      b.ignore('sheetify/insert')
+      b.transform(sheetify, opts.css)
+    }
+
+    return watchifyRequest(b)
+
+    function createCssStream () {
+      return concat({ encoding: 'buffer' }, function (css) {
+        self._css = css
+        while (self.cssQueue.length) self.cssQueue.shift()()
+      })
+    }
+  })()
 }
 
 // (obj, obj) -> readStream
 Bankai.prototype.js = function (req, res) {
   const through$ = new stream.PassThrough()
-  this._createJs(req, res, function (err, buffer) {
+  this._js(req, res, function (err, buffer) {
     if (err) return through$.emit('error', err)
     const source$ = from([buffer])
     pump(source$, through$)
@@ -53,14 +89,14 @@ Bankai.prototype.js = function (req, res) {
 
 // (obj, obj) -> readStream
 Bankai.prototype.html = function (req, res) {
-  assert.ok(this.htmlDisabled !== false, 'bankai: html is disabled')
+  assert.notEqual(this.htmlDisabled, true, 'bankai: html is disabled')
   if (res) res.setHeader('Content-Type', 'text/html')
   return from([this._html])
 }
 
 // (obj, obj) -> readStream
 Bankai.prototype.css = function (req, res) {
-  assert.ok(this.cssDisabled !== false, 'bankai: css is disabled')
+  assert.notEqual(this.cssDisabled, true, 'bankai: css is disabled')
   if (res) res.setHeader('Content-Type', 'text/css')
   if (!this._css) {
     const self = this
@@ -72,41 +108,5 @@ Bankai.prototype.css = function (req, res) {
     return through
   } else {
     return from([this._css])
-  }
-}
-
-function _html (opts) {
-  const base = {
-    script: 'bundle.js',
-    css: 'bundle.css',
-    head: '<meta name="viewport" content="width=device-width, initial-scale=1">'
-  }
-  const html = createHtml(xtend(base, opts || {}))
-  return new Buffer(html)
-}
-
-// create a js watcher
-function _javascript (entry, opts, setCss) {
-  const base = {
-    basedir: process.cwd(),
-    entries: [ entry ],
-    packageCache: {},
-    fullPaths: true,
-    cache: {}
-  }
-
-  opts = xtend(base, opts || {})
-
-  const b = (this.optimize)
-    ? browserify(opts)
-    : watchify(browserify(opts))
-  b.ignore('sheetify/insert')
-  b.plugin(cssExtract, { out: createCssStream })
-  b.transform(sheetify)
-
-  return watchifyRequest(b)
-
-  function createCssStream () {
-    return concat({ encoding: 'buffer' }, setCss)
   }
 }


### PR DESCRIPTION
- inlined `_css` and `_js` statements
- fixed options passing (as per #93)
- added debug statement
- reordered argument list in bin
- added alias for `--html`
- supersedes https://github.com/yoshuawuyts/bankai/pull/93
- fixed merge conflicts with master