### PR TITLE
feat(index): ignore electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ function Bankai (entry, opts) {
       ? browserify(jsOpts)
       : watchify(browserify(jsOpts))
 
+    b.ignore('electron')
+
     if (!self.cssDisabled) {
       b.plugin(cssExtract, { out: createCssStream })
       b.ignore('sheetify/insert')


### PR DESCRIPTION
Ignore electron by default so we can bundle full apps for electron and like not have to worry electron's built-ins will be picked up in the bundle