### PR TITLE
add assets option to cli docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,16 @@ http.createServer((req, res) => {
     build <filename> <directory>   Compile and export files to a directory
 
     Options:
-      -c, --css=<subargs>     Pass subarguments to sheetify
-      -d, --debug             Include sourcemaps [default: false]
-      -h, --help              Print usage
-      -H, --html=<subargs>    Pass subarguments to create-html
-      -j, --js=<subargs>      Pass subarguments to browserify
-      -o, --open=<browser>    Open html in a browser [default: system default]
-      -O, --optimize          Optimize assets served by bankai [default: false]
-      -p, --port=<n>          Bind bankai to a port [default: 8080]
-      -V, --verbose           Include debug messages
+      -a, --assets=<directory>  Serve static assets [default: assets]
+      -c, --css=<subargs>       Pass subarguments to sheetify
+      -d, --debug               Include sourcemaps [default: false]
+      -h, --help                Print usage
+      -H, --html=<subargs>      Pass subarguments to create-html
+      -j, --js=<subargs>        Pass subarguments to browserify
+      -o, --open=<browser>      Open html in a browser [default: system default]
+      -O, --optimize            Optimize assets served by bankai [default: false]
+      -p, --port=<n>            Bind bankai to a port [default: 8080]
+      -V, --verbose             Include debug messages
 
   Examples:
     $ bankai index.js -p 8080            # start bankai on port 8080


### PR DESCRIPTION
Helllooo!

I was trying to check whether :sparkles: rumours were true :sparkles: and bankai takes an `assets` flag (and it does, yay!). Noticed the aforementioned flag was missing from the cli docs. This is the tiniest half-a-line pull request to add it. 

Thank you ^___^