### PR TITLE
fix assets not serving (#136)

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -134,7 +134,7 @@ function start (entry, argv, done) {
     } else if (req.headers['accept'].indexOf('html') > 0) {
       assets.html(req, res).pipe(sink)
     } else if (staticAsset.test(req.url)) {
-      assets.static(req, res).pipe(sink)
+      assets.static(req).pipe(res)
     } else {
       res.writeHead(404, 'Not Found')
       sink.end()


### PR DESCRIPTION
2c13e255ce7ffa3fff8e3a8b424d398ffceb472d added response size logging via
`server-sink`, which acts as a passthrough stream between `req` and `res`.

However, `send`, which streams the static files from disk, has a stateful
`pipe()` method and assumes that the destination stream is an
HttpServerResponse. Since the sink through stream is not, things break.

This PR just foregoes response size logging on assets. I'd be happy with just
changing the static stream code to simply

```
fs.createReadStream(req.url.substring(1)).pipe(sink)
```

but we'd lose out on the fancy features of `send` (if they're desired by
others). Modifying `send` itself to be tolerant of intermediary passthrough
streams looks difficult -- there are some pretty deep assumptions in place
about it knowing where the `res` is and being able to mutate it.