### PR TITLE
Updated js and css default paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ function Bankai (entry, opts) {
 
   function html () {
     var base = {
-      script: '/bundle.js',
-      css: self.cssDisabled ? null : '/bundle.css',
+      script: './bundle.js',
+      css: self.cssDisabled ? null : './bundle.css',
       head: '<meta name="viewport" content="width=device-width, initial-scale=1">'
     }
     var html = createHtml(xtend(base, opts.html))


### PR DESCRIPTION
The compiled html files has the js and css path written in this way: `/bundle.*`.
I don't know if others have encountered my same problem, but both chrome and electron throw the following exception: `Failed to load resource: net::ERR_FILE_NOT_FOUND`.

With this fix it will not happen anymore.

Cheers!

ps if I'm doing something wrong, please let me know, maybe is just me :)