### PR TITLE
enable asserts in start

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ take the following options:
 - __opts.electron:__ (default `false`). Enable [electron][electron] mode for
   the bundler.  Relies on `index.html` being served as a static file using
   `file://` to ensure `require()` paths are resolved correctly
+- __opts.assert:__ (default: `true`) disable all calls to `require('assert')`
 
 ### readableStream = assets.js([req], [res])
 Return a `js` stream. Sets correct header values if `req` and `res` are passed.

--- a/bin.js
+++ b/bin.js
@@ -143,7 +143,6 @@ function main (argv) {
 }
 
 function start (entry, argv, done) {
-  // always enable watch for start
   log.debug('running command: start')
   argv.watch = true
 
@@ -209,6 +208,7 @@ function build (entry, outputDir, argv, done) {
 
   // cast argv.watch to a boolean
   argv.watch = argv.watch === undefined ? false : argv.watch
+  argv.assert = false
 
   mkdirp.sync(outputDir)
   buildStaticAssets(entry, outputDir, argv, done)

--- a/index.js
+++ b/index.js
@@ -82,7 +82,10 @@ function Bankai (entry, opts) {
       b.transform(sheetify, opts.css)
     }
 
-    b.transform(unassertify, { global: true })
+    if (opts.assert === false || opts.assert === 'false') {
+      b.transform(unassertify, { global: true })
+    }
+
     b.transform(yoyoify, { global: true })
     b.transform(envify, { global: true })
 


### PR DESCRIPTION
- new option `opts.assert`
- enable asserts in `start`
- disable asserts in `build`

Fixes a regression we had in the last major where _all_ asserts were getting stripped. We only wanna strip asserts when writing to disc I think.