### PR TITLE
update bankai to use uglify-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "temp-path": "^1.0.0",
     "through2": "^2.0.3",
     "uglify-es": "^3.0.15",
-    "uglifyify": "^3.0.4",
+    "uglifyify": "^4.0.0",
     "unassertify": "^2.0.3",
     "watchify": "^3.7.0",
     "watchify-request": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "subarg": "^1.0.0",
     "temp-path": "^1.0.0",
     "through2": "^2.0.3",
-    "uglify-js": "^2.8.22",
+    "uglify-es": "^3.0.15",
     "uglifyify": "^3.0.4",
     "unassertify": "^2.0.3",
     "watchify": "^3.7.0",


### PR DESCRIPTION
This PR brings in the new-and-improved version of [uglify](https://github.com/mishoo/UglifyJS2/tree/harmony) that is meant to handle es6 syntax better than the previous versions. This merge is dependant on [uglifyify pr](https://github.com/hughsk/uglifyify/pull/65) getting merged first to avoid weirdness with the option changes (there have been a lot between the versions).

Since there have been quite a few option changes, I think we might be able to compress things a lot further with some of these. I haven't added anything aside from the options you've previously had, but if something else [out of the list](https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options) peaks your interest, let me know and I can add it. 

I've also added `uglify` option to the boolean list, which might help with some of the non-boolean values you've been getting.

Thanks a bunch ✨

(cc @toddself @yoshuawuyts)