### PR TITLE
don't uglify in debug mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,7 @@ function Bankai (entry, opts) {
         collapse_vars: true
       }
     }
-    if (opts.debug) uglifyOpts.sourceMap = { filename: entry }
-    b.transform(uglifyify, uglifyOpts)
+    if (!opts.debug) b.transform(uglifyify, uglifyOpts)
 
     b.plugin(collapser)
 


### PR DESCRIPTION
It's easier to track down values and variables in debug / development mode when uglify is turned off. This PR doesn't uglify in debug.

Thanks!